### PR TITLE
Add CDN links

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ npm install react-imgpro
 This also depends on `react` so make sure you've installed it.
 
 
+Alternatively you can include it from a CDN:
+
+```
+<script src="https://cdn.jsdelivr.net/npm/react@16/umd/react.production.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/react-imgpro@1/build/main.js"></script>
+```
+
 ## Usage
 
 ```jsx

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ npm install react-imgpro
 
 This also depends on `react` so make sure you've installed it.
 
+OR
 
-Alternatively you can include it from a CDN:
+The UMD build is also available on [jsDelivr](https://www.jsdelivr.com).
 
 ```
 <script src="https://cdn.jsdelivr.net/npm/react@16/umd/react.production.min.js"></script>


### PR DESCRIPTION
I added [jsDelivr CDN links](https://www.jsdelivr.com/package/npm/react-imgpro) to your readme so that people can use files directly without downloading them. jsDelivr is also the [fastest opensource CDN](https://www.cdnperf.com/) available and built specifically for production usage. 